### PR TITLE
Include version as default require

### DIFF
--- a/lib/metanorma/ogc.rb
+++ b/lib/metanorma/ogc.rb
@@ -1,3 +1,4 @@
+require "metanorma/ogc/version"
 require "metanorma/ogc/processor"
 
 module Metanorma


### PR DESCRIPTION
The current version doesn't explicitly include the `version` file, so when `metanorma-cli` tries to retrieves the version then it throws an error: https://github.com/metanorma/metanorma-cli/issues/98#issue-469807545

This commit include the version, so now `metanorma-cli` should not have any issue with displaying the version without having to require it