### PR TITLE
Add `--output-dir` functionality

### DIFF
--- a/lib/metanorma/ogc/processor.rb
+++ b/lib/metanorma/ogc/processor.rb
@@ -30,10 +30,6 @@ module Metanorma
         "Metanorma::Ogc #{Metanorma::Ogc::VERSION}"
       end
 
-      def input_to_isodoc(file, filename)
-        Metanorma::Input::Asciidoc.new.process(file, filename, @asciidoctor_backend)
-      end
-
       def output(isodoc_node, inname, outname, format, options={})
         case format
         when :html


### PR DESCRIPTION
move the Metanorma::Ogc::Processor#input_to_isodoc method to Metanorma::Processor
metanorma/metanorma-cli#134