### PR TITLE
ci: install Inkscape dependency for specs

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/generic-rake.yml@feat/add-inkscape-setup-step
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
     with:
       setup-inkscape: true
     secrets:


### PR DESCRIPTION
This PR installs the library using the appropriate package manager for each platform.

closes metanorma/isodoc#766