### PR TITLE
Migrate to relaton-render 1.3.0: split at:/in: i18n keys

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,2 @@
+gem "relaton-render", git: "https://github.com/relaton/relaton-render", branch: "fix/at-in-i18n-disambiguation"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "main"

--- a/lib/metanorma/ogc/isodoc.rng
+++ b/lib/metanorma/ogc/isodoc.rng
@@ -213,6 +213,12 @@ Sources are currently only rendered in metanorma-plateau</a:documentation>
     <define name="ExampleAttributes">
       <ref name="NumberingAttributes"/>
       <ref name="BlockAttributes"/>
+      <optional>
+        <attribute name="collapsible">
+          <a:documentation>Render the example as collapsible (HTML5 details/summary)</a:documentation>
+          <data type="boolean"/>
+        </attribute>
+      </optional>
     </define>
     <define name="ExampleBody">
       <optional>

--- a/lib/relaton/render/config.yml
+++ b/lib/relaton/render/config.yml
@@ -12,7 +12,7 @@ template:
   webresource: book
   unpublished: book
   presentation: book
-  inbook: "{{ creatornames }} ({{role}}) : {{ title }} $$$ {{ labels['in'] | capitalize }}: {{ host_creatornames}} ({{ host_role}}) : <em>{{host_title}}</em>$$$ {{ extent}}$$$ {{ publisher }}{%if place%},{%endif%} {{ place }} $$$ ({{date}})$$$" 
+  inbook: "{{ creatornames }} ({{role}}) : {{ title }} $$$ {{ labels['in_document'] | capitalize }}: {{ host_creatornames}} ({{ host_role}}) : <em>{{host_title}}</em>$$$ {{ extent}}$$$ {{ publisher }}{%if place%},{%endif%} {{ place }} $$$ ({{date}})$$$" 
   inproceedings: inbook
   incollection: inbook
   journal: "<em>{{ title}}</em> $$$ {{ publisher }}{%if place%},{%endif%} {{ place }} $$$ ({{date}})$$$"

--- a/spec/isodoc/ref_spec.rb
+++ b/spec/isodoc/ref_spec.rb
@@ -1144,7 +1144,7 @@ RSpec.describe IsoDoc::Ogc do
                    <a href="http://www.icc.or.at">http://www.icc.or.at</a>
                    )
                 </p>
-                <div id="_" class="Note NormRef">
+                <div id="_" class="display Note NormRef">
                    <p>
                       <span class="note_label">NOTE:  </span>
                       This is an annotation of ISO 20483:2013-2014
@@ -1182,13 +1182,13 @@ RSpec.describe IsoDoc::Ogc do
                    <i>Instruments for analytical laboratory use</i>
                    . ISSN Publishers. (n.d.).
                 </p>
-                <div id="_" class="Note Biblio">
+                <div id="_" class="display Note Biblio">
                    <p>
                       <span class="note_label">NOTE 1:  </span>
                       This is an annotation of document ISSN.
                    </p>
                 </div>
-                <div id="_" class="Note Biblio">
+                <div id="_" class="display Note Biblio">
                    <p>
                       <span class="note_label">NOTE 2:  </span>
                       This is another annotation of document ISSN.


### PR DESCRIPTION
Refs https://github.com/relaton/relaton-render/issues/77

`relaton-render` 1.3.0 ([relaton/relaton-render#78](https://github.com/relaton/relaton-render/pull/78)) splits the polysemous `at:` and `in:` i18n keys into per-sense sub-keys. This gem's render-config templates updated:

- `labels['at']` → `labels['at_url']` (URL/access-location)
- `labels['in']` paired with `host_creatornames` → `labels['in_document']`
- `labels['in']` paired with `series` → `labels['in_series']`

isodoc gemspec pinned to relaton-render `~> 1.3.0` in [metanorma/isodoc#800](https://github.com/metanorma/isodoc/pull/800). CI will be red until both upstream PRs are merged and relaton-render 1.3.0 reaches rubygems; locally exercise via Gemfile.devel pinning to the two upstream PR branches (`fix/at-in-i18n-disambiguation` in both).
