### PR TITLE
chore(ci): cimas sync 2026-06-24 — required_ruby_version >= 3.3, automerge v0.16.4 pin, lutaml Makefile (refs metanorma/ci#274 #283 #281 #300)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,6 +26,6 @@ jobs:
     steps:
       - id: automerge
         name: automerge
-        uses: "pascalgn/automerge-action@v0.16.4"
+        uses: pascalgn/automerge-action@v0.16.4
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/metanorma-ogc.gemspec
+++ b/metanorma-ogc.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
 
   spec.add_dependency "iso-639"
   spec.add_dependency "metanorma-standoc", "~> 3.4.2"


### PR DESCRIPTION
As title. 

 _Generated by Cimas_.