### PR TITLE
Configurable publisher bibliography sort order

### DIFF
--- a/lib/metanorma/ogc/cleanup.rb
+++ b/lib/metanorma/ogc/cleanup.rb
@@ -146,14 +146,15 @@ module Metanorma
 
       PUBLISHER = "./contributor[role/@type = 'publisher']/organization".freeze
 
-      def pub_class(bib)
-        return 1 if bib.at("#{PUBLISHER}[abbreviation = 'OGC']")
-        return 1 if bib.at("#{PUBLISHER}[name = 'Open Geospatial " \
-                           "Consortium']")
-        return 2 if bib.at("./docidentifier[@type][not(#{@conv.skip_docid} or " \
-                           "@type = 'metanorma')]")
+      # OGC first, then other standards, then everything else. Overridable
+      # per-document / per-taste via :sort-biblio-<abbrev>: through the shared
+      # Standoc::Ref helpers.
+      DEFAULT_PUBLISHER_SORT = [
+        { abbrev: "OGC", name: "Open Geospatial Consortium", rank: 1 },
+      ].freeze
 
-        3
+      def pub_class(bib)
+        publisher_sort_rank(bib, DEFAULT_PUBLISHER_SORT)
       end
 
       # sort by: doc class (OGC, other standard (not DOI &c), other


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-oiml/issues/12

`pub_class` delegates to the shared helper with an OGC default table. Default sort output unchanged (refs_spec green).

Part of the stack-wide configurable bibliography publisher-sort feature. The bibliography's publisher sort order becomes overridable via `:sort-biblio-<abbrev>: <rank>: <name>` document attributes — set directly in a document, or injected by a metanorma-taste config. Full diagnosis, design, per-gem breakdown and verification are on the ticket.

🤖
